### PR TITLE
Using type quotations instead of identifiers for specifying functions

### DIFF
--- a/geniplate.cabal
+++ b/geniplate.cabal
@@ -1,5 +1,5 @@
 Name:           geniplate
-Version:        0.6.0.5
+Version:        0.6.0.6
 Synopsis:       Use Template Haskell to generate Uniplate-like functions.
 Description:    Use Template Haskell to generate Uniplate-like functions.
 Bug-reports:    https://github.com/haskell/augustss/geniplate/issues


### PR DESCRIPTION
In calls to `genUniverseBi*` and `genTransformBi*`, the desired type for the generated function is given by means of the name of an identifier in scope with the desired type. This saves some keystrokes by allowing to give the same identifier that was bound to the result of the Template Haskell splice.

In GHC 7.8, Template Haskell splices can no longer access local bindings. The current approach now compels the user to define dummy identifier for the desired type, and then pass that to the splice.

I've created _primed_ versions of the functions that take the types as a type splice. As a bonus, and combined with the ScopedTypeVariables extensions, this allows for creating polymorphic functions without the need for an explicit "forall", by binding to local type variables.
