### PR TITLE
Bump template-haskell dependency to work with GHC 7.10.1

### DIFF
--- a/geniplate.cabal
+++ b/geniplate.cabal
@@ -22,6 +22,6 @@ source-repository head
   location: https://github.com/augustss/geniplate
 
 library
-  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.10, mtl
+  Build-Depends: base >= 4 && < 5.0, template-haskell < 2.12, mtl
 
   Exposed-modules:      Data.Generics.Geniplate

--- a/geniplate.cabal
+++ b/geniplate.cabal
@@ -2,7 +2,7 @@ Name:           geniplate
 Version:        0.6.0.6
 Synopsis:       Use Template Haskell to generate Uniplate-like functions.
 Description:    Use Template Haskell to generate Uniplate-like functions.
-Bug-reports:    https://github.com/haskell/augustss/geniplate/issues
+Bug-reports:    https://github.com/augustss/geniplate/issues
 License:        BSD3
 License-File:   LICENSE
 Author:         Lennart Augustsson


### PR DESCRIPTION
`geniplate` does not build with GHC 7.10.1 because of dependency on Template Haskell version. Luckily bumping the upper limit on template-haskell dependency is enough to fix the problem.

`geniplate` not working with GHC 7.10.1 makes it impossible to build Agda and I think that's a serious problem, so updating the version of `geniplate` on Hackage would be nice.
